### PR TITLE
feat: model_id tag add omitempty

### DIFF
--- a/client/types/types.go
+++ b/client/types/types.go
@@ -19,7 +19,7 @@ type Voice struct {
 	Labels      string     `json:"labels,omitempty"`      // Serialized labels dictionary for the voice.
 }
 type TTS struct {
-	ModelID       string           `json:"model_id"`
+	ModelID       string           `json:"model_id,omitempty"`
 	Text          string           `json:"text"`                     // The text that will get converted into speech. Currently only English text is supported.
 	VoiceSettings SynthesisOptions `json:"voice_settings,omitempty"` // Voice settings are applied only on the given TTS request.
 }


### PR DESCRIPTION
[elevenlabs api-reference](https://docs.elevenlabs.io/api-reference/text-to-speech-stream
)

<img width="313" alt="image" src="https://github.com/taigrr/elevenlabs/assets/27660932/eda96089-86b6-4119-8ae8-bfa2d35f4379">

@taigrr hi, there:
If the model_id is not specified, the model_id is an empty string after json.marshal(), and the interface will report a 500 error
`{"model_id":"","text":"hello world","voice_settings":{"stability":0.75,"similarity_boost":0.75}}`

