### PR TITLE
Fix: check errors before accessing pointer receiver (!)

### DIFF
--- a/client/history.go
+++ b/client/history.go
@@ -151,14 +151,14 @@ func (c Client) HistoryDownloadAudioWriter(ctx context.Context, w io.Writer, ID 
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		defer res.Body.Close()
 		io.Copy(w, res.Body)
 		return nil
@@ -188,14 +188,14 @@ func (c Client) HistoryDownloadAudio(ctx context.Context, ID string) ([]byte, er
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
 	res, err := client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
 
 	switch res.StatusCode {
 	case 401:
 		return []byte{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return []byte{}, err
-		}
 		b := bytes.Buffer{}
 		w := bufio.NewWriter(&b)
 
@@ -228,15 +228,14 @@ func (c Client) GetHistoryItemList(ctx context.Context) ([]types.HistoryItemList
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return []types.HistoryItemList{}, err
+	}
 
 	switch res.StatusCode {
 	case 401:
 		return []types.HistoryItemList{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return []types.HistoryItemList{}, err
-		}
-
 		var history types.GetHistoryResponse
 		defer res.Body.Close()
 		jerr := json.NewDecoder(res.Body).Decode(&history)

--- a/client/samples.go
+++ b/client/samples.go
@@ -25,14 +25,13 @@ func (c Client) DeleteVoiceSample(ctx context.Context, voiceID, sampleID string)
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	res, err := client.Do(req)
-
+	if err != nil {
+		return false, err
+	}
 	switch res.StatusCode {
 	case 401:
 		return false, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return false, err
-		}
 		return true, nil
 	case 422:
 		fallthrough
@@ -60,14 +59,14 @@ func (c Client) DownloadVoiceSampleWriter(ctx context.Context, w io.Writer, voic
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		defer res.Body.Close()
 		io.Copy(w, res.Body)
 		return nil
@@ -97,14 +96,14 @@ func (c Client) DownloadVoiceSample(ctx context.Context, voiceID, sampleID strin
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
 	res, err := client.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
 
 	switch res.StatusCode {
 	case 401:
 		return []byte{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return []byte{}, err
-		}
 		b := bytes.Buffer{}
 		w := bufio.NewWriter(&b)
 

--- a/client/user.go
+++ b/client/user.go
@@ -20,15 +20,13 @@ func (c Client) GetUserInfo(ctx context.Context) (types.UserResponseModel, error
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
-
+	if err != nil {
+		return types.UserResponseModel{}, err
+	}
 	switch res.StatusCode {
 	case 401:
 		return types.UserResponseModel{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return types.UserResponseModel{}, err
-		}
-
 		var user types.UserResponseModel
 		defer res.Body.Close()
 		jerr := json.NewDecoder(res.Body).Decode(&user)
@@ -53,5 +51,8 @@ func (c Client) GetUserInfo(ctx context.Context) (types.UserResponseModel, error
 
 func (c Client) GetSubscriptionInfo(ctx context.Context) (types.Subscription, error) {
 	info, err := c.GetUserInfo(ctx)
+	if err != nil {
+		return types.Subscription{}, err
+	}
 	return info.Subscription, err
 }

--- a/client/voices.go
+++ b/client/voices.go
@@ -44,13 +44,13 @@ func (c Client) CreateVoice(ctx context.Context, name, description string, label
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		return nil
 	case 422:
 		fallthrough
@@ -78,13 +78,13 @@ func (c Client) DeleteVoice(ctx context.Context, voiceID string) error {
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		return nil
 	case 422:
 		fallthrough
@@ -114,13 +114,13 @@ func (c Client) EditVoiceSettings(ctx context.Context, voiceID string, settings 
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		so := types.SynthesisOptions{}
 		defer res.Body.Close()
 		jerr := json.NewDecoder(res.Body).Decode(&so)
@@ -172,13 +172,13 @@ func (c Client) EditVoice(ctx context.Context, voiceID, name, description string
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 	switch res.StatusCode {
 	case 401:
 		return ErrUnauthorized
 	case 200:
-		if err != nil {
-			return err
-		}
 		return nil
 	case 422:
 		fallthrough
@@ -206,13 +206,13 @@ func (c Client) defaultVoiceSettings(ctx context.Context) (types.SynthesisOption
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return types.SynthesisOptions{}, err
+	}
 	switch res.StatusCode {
 	case 401:
 		return types.SynthesisOptions{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return types.SynthesisOptions{}, err
-		}
 		so := types.SynthesisOptions{}
 		defer res.Body.Close()
 		jerr := json.NewDecoder(res.Body).Decode(&so)
@@ -246,13 +246,13 @@ func (c Client) GetVoiceSettings(ctx context.Context, voiceID string) (types.Syn
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
 	res, err := client.Do(req)
+	if err != nil {
+		return types.SynthesisOptions{}, err
+	}
 	switch res.StatusCode {
 	case 401:
 		return types.SynthesisOptions{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return types.SynthesisOptions{}, err
-		}
 		so := types.SynthesisOptions{}
 		defer res.Body.Close()
 		jerr := json.NewDecoder(res.Body).Decode(&so)


### PR DESCRIPTION
## Problem

`http.Do` returns an `*http.Response`. This is received by a pointer. If that pointer does not receive an address to a memory location, and instead ends up being `nil`, and we try to access the contents of what would otherwise be a response, the application will panic.

This means that anyone that uses this library as it sits before this PR, if they do not implement panic recovery and have enough of a blip in their network to fail a request, or elevenlabs has a blip on their end.. *the entire application will panic, crash, and burn*. 

## Solution

This PR fixes this issue by checking the error type of this method *first*, before referencing the pointer receiver. It also removes the check for an error after determining we have a 200 response, because we already know by then the error is nil.

## Reference

When an error occurs following a call to the method `http.Do`, there seems to be no realistic case where you end up with both a non-nil `*http.Response` _(especially one with a response status of 200)_, and an error.

[See the following](https://github.com/golang/go/blob/ac64a3628b54f47dc3aa84fc4527fd753db7b834/src/net/http/client.go#L595-L744):

<details>

<summary>net/http/client.go</summary>

```go
   func (c *Client) do(req *Request) (retres *Response, reterr error) {
        if testHookClientDoResult != nil {
                defer func() { testHookClientDoResult(retres, reterr) }()
        }
        if req.URL == nil {
                req.closeBody()
                return nil, &url.Error{
                        Op:  urlErrorOp(req.Method),
                        Err: errors.New("http: nil Request.URL"),
                }
        }


        var (
                deadline      = c.deadline()
                reqs          []*Request
                resp          *Response
                copyHeaders   = c.makeHeadersCopier(req)
                reqBodyClosed = false // have we closed the current req.Body?


                // Redirect behavior:
                redirectMethod string
                includeBody    bool
        )
        uerr := func(err error) error {
                // the body may have been closed already by c.send()
                if !reqBodyClosed {
                        req.closeBody()
                }
                var urlStr string
                if resp != nil && resp.Request != nil {
                        urlStr = stripPassword(resp.Request.URL)
                } else {
                        urlStr = stripPassword(req.URL)
                }
                return &url.Error{
                        Op:  urlErrorOp(reqs[0].Method),
                        URL: urlStr,
                        Err: err,
                }
        }
        for {
                // For all but the first request, create the next
                // request hop and replace req.
                if len(reqs) > 0 {
                        loc := resp.Header.Get("Location")
                        if loc == "" {
                                // While most 3xx responses include a Location, it is not
                                // required and 3xx responses without a Location have been
                                // observed in the wild. See issues #17773 and #49281.
                                return resp, nil
                        }
                        u, err := req.URL.Parse(loc)
                        if err != nil {
                                resp.closeBody()
                                return nil, uerr(fmt.Errorf("failed to parse Location header %q: %v", loc, err))
                        }
                        host := ""
                        if req.Host != "" && req.Host != req.URL.Host {
                                // If the caller specified a custom Host header and the
                                // redirect location is relative, preserve the Host header
                                // through the redirect. See issue #22233.
                                if u, _ := url.Parse(loc); u != nil && !u.IsAbs() {
                                        host = req.Host
                                }
                        }
                        ireq := reqs[0]
                        req = &Request{
                                Method:   redirectMethod,
                                Response: resp,
                                URL:      u,
                                Header:   make(Header),
                                Host:     host,
                                Cancel:   ireq.Cancel,
                                ctx:      ireq.ctx,
                        }
                        if includeBody && ireq.GetBody != nil {
                                req.Body, err = ireq.GetBody()
                                if err != nil {
                                        resp.closeBody()
                                        return nil, uerr(err)
                                }
                                req.ContentLength = ireq.ContentLength
                        }


                        // Copy original headers before setting the Referer,
                        // in case the user set Referer on their first request.
                        // If they really want to override, they can do it in
                        // their CheckRedirect func.
                        copyHeaders(req)


                        // Add the Referer header from the most recent
                        // request URL to the new one, if it's not https->http:
                        if ref := refererForURL(reqs[len(reqs)-1].URL, req.URL, req.Header.Get("Referer")); ref != "" {
                                req.Header.Set("Referer", ref)
                        }
                        err = c.checkRedirect(req, reqs)


                        // Sentinel error to let users select the
                        // previous response, without closing its
                        // body. See Issue 10069.
                        if err == ErrUseLastResponse {
                                return resp, nil
                        }


                        // Close the previous response's body. But
                        // read at least some of the body so if it's
                        // small the underlying TCP connection will be
                        // re-used. No need to check for errors: if it
                        // fails, the Transport won't reuse it anyway.
                        const maxBodySlurpSize = 2 << 10
                        if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
                                io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
                        }
                        resp.Body.Close()


                        if err != nil {
                                // Special case for Go 1 compatibility: return both the response
                                // and an error if the CheckRedirect function failed.
                                // See https://golang.org/issue/3795
                                // The resp.Body has already been closed.
                                ue := uerr(err)
                                ue.(*url.Error).URL = loc
                                return resp, ue
                        }
                }
```

</details>

