### PR TITLE
add WithHTTPClient

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"net/http"
 )
 
 const apiEndpoint = "https://api.elevenlabs.io"
@@ -12,18 +13,31 @@ var (
 )
 
 type Client struct {
-	apiKey   string
-	endpoint string
+	apiKey     string
+	endpoint   string
+	httpClient *http.Client
 }
 
 func New(apiKey string) Client {
 	return Client{
-		apiKey:   apiKey,
-		endpoint: apiEndpoint,
+		apiKey:     apiKey,
+		endpoint:   apiEndpoint,
+		httpClient: &http.Client{},
 	}
 }
 
 func (c Client) WithEndpoint(endpoint string) Client {
 	c.endpoint = endpoint
+	return c
+}
+
+func (c Client) WithAPIKey(apiKey string) Client {
+	c.apiKey = apiKey
+	return c
+}
+
+// WithHTTPClient allows users to provide their own http.Client
+func (c Client) WithHTTPClient(hc *http.Client) Client {
+	c.httpClient = hc
 	return c
 }

--- a/client/history.go
+++ b/client/history.go
@@ -15,8 +15,6 @@ import (
 
 func (c Client) HistoryDelete(ctx context.Context, historyItemID string) (bool, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/history/%s", historyItemID)
-
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return false, err
@@ -24,7 +22,7 @@ func (c Client) HistoryDelete(ctx context.Context, historyItemID string) (bool, 
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	switch res.StatusCode {
 	case 401:
@@ -55,7 +53,6 @@ func (c Client) HistoryDownloadZipWriter(ctx context.Context, w io.Writer, id1, 
 	toDownload := types.HistoryPost{
 		HistoryItemIds: downloads,
 	}
-	client := &http.Client{}
 	body, _ := json.Marshal(toDownload)
 	bodyReader := bytes.NewReader(body)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
@@ -66,7 +63,7 @@ func (c Client) HistoryDownloadZipWriter(ctx context.Context, w io.Writer, id1, 
 	req.Header.Set("accept", "archive/zip")
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	switch res.StatusCode {
 	case 401:
@@ -99,7 +96,6 @@ func (c Client) HistoryDownloadZip(ctx context.Context, id1, id2 string, additio
 	toDownload := types.HistoryPost{
 		HistoryItemIds: downloads,
 	}
-	client := &http.Client{}
 	body, _ := json.Marshal(toDownload)
 	bodyReader := bytes.NewReader(body)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
@@ -110,7 +106,7 @@ func (c Client) HistoryDownloadZip(ctx context.Context, id1, id2 string, additio
 	req.Header.Set("accept", "archive/zip")
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 
 	switch res.StatusCode {
 	case 401:
@@ -142,7 +138,6 @@ func (c Client) HistoryDownloadZip(ctx context.Context, id1, id2 string, additio
 
 func (c Client) HistoryDownloadAudioWriter(ctx context.Context, w io.Writer, ID string) error {
 	url := fmt.Sprintf(c.endpoint+"/v1/history/%s/audio", ID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -150,7 +145,7 @@ func (c Client) HistoryDownloadAudioWriter(ctx context.Context, w io.Writer, ID 
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -179,7 +174,6 @@ func (c Client) HistoryDownloadAudioWriter(ctx context.Context, w io.Writer, ID 
 
 func (c Client) HistoryDownloadAudio(ctx context.Context, ID string) ([]byte, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/history/%s/audio", ID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []byte{}, err
@@ -187,7 +181,7 @@ func (c Client) HistoryDownloadAudio(ctx context.Context, ID string) ([]byte, er
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -219,7 +213,6 @@ func (c Client) HistoryDownloadAudio(ctx context.Context, ID string) ([]byte, er
 
 func (c Client) GetHistoryItemList(ctx context.Context) ([]types.HistoryItemList, error) {
 	url := c.endpoint + "/v1/history"
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []types.HistoryItemList{}, err
@@ -227,7 +220,7 @@ func (c Client) GetHistoryItemList(ctx context.Context) ([]types.HistoryItemList
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return []types.HistoryItemList{}, err
 	}

--- a/client/samples.go
+++ b/client/samples.go
@@ -15,7 +15,6 @@ import (
 
 func (c Client) DeleteVoiceSample(ctx context.Context, voiceID, sampleID string) (bool, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/samples/%s", voiceID, sampleID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return false, err
@@ -24,7 +23,7 @@ func (c Client) DeleteVoiceSample(ctx context.Context, voiceID, sampleID string)
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -50,7 +49,6 @@ func (c Client) DeleteVoiceSample(ctx context.Context, voiceID, sampleID string)
 
 func (c Client) DownloadVoiceSampleWriter(ctx context.Context, w io.Writer, voiceID, sampleID string) error {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/samples/%s/audio", voiceID, sampleID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -58,7 +56,7 @@ func (c Client) DownloadVoiceSampleWriter(ctx context.Context, w io.Writer, voic
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -87,7 +85,6 @@ func (c Client) DownloadVoiceSampleWriter(ctx context.Context, w io.Writer, voic
 
 func (c Client) DownloadVoiceSample(ctx context.Context, voiceID, sampleID string) ([]byte, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/samples/%s/audio", voiceID, sampleID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []byte{}, err
@@ -95,7 +92,7 @@ func (c Client) DownloadVoiceSample(ctx context.Context, voiceID, sampleID strin
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/client/sound_gen.go
+++ b/client/sound_gen.go
@@ -68,8 +68,6 @@ func (c Client) SoundGeneration(ctx context.Context, text string, durationSecond
 
 func (c Client) requestSoundGeneration(ctx context.Context, params types.SoundGeneration) (io.ReadCloser, error) {
 	url := c.endpoint + "/v1/sound-generation"
-	client := &http.Client{}
-
 	b, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
@@ -84,7 +82,7 @@ func (c Client) requestSoundGeneration(ctx context.Context, params types.SoundGe
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
 
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/stt.go
+++ b/client/stt.go
@@ -75,7 +75,6 @@ func (c *Client) ConvertSpeechToTextFromReader(ctx context.Context, reader io.Re
 		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	client := &http.Client{}
 	url := fmt.Sprintf(c.endpoint + "/v1/speech-to-text")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
@@ -86,7 +85,7 @@ func (c *Client) ConvertSpeechToTextFromReader(ctx context.Context, reader io.Re
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("xi-api-key", c.apiKey)
 
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}

--- a/client/tts.go
+++ b/client/tts.go
@@ -88,7 +88,6 @@ func (c Client) requestTTS(ctx context.Context, params types.TTS, options types.
 	if params.Stream {
 		url += "/stream"
 	}
-	client := &http.Client{}
 	b, _ := json.Marshal(params)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(b))
 	if err != nil {
@@ -97,7 +96,7 @@ func (c Client) requestTTS(ctx context.Context, params types.TTS, options types.
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "audio/mpeg")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/user.go
+++ b/client/user.go
@@ -11,7 +11,6 @@ import (
 
 func (c Client) GetUserInfo(ctx context.Context) (types.UserResponseModel, error) {
 	url := c.endpoint + "/v1/user"
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return types.UserResponseModel{}, err
@@ -19,7 +18,7 @@ func (c Client) GetUserInfo(ctx context.Context) (types.UserResponseModel, error
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return types.UserResponseModel{}, err
 	}

--- a/client/voices.go
+++ b/client/voices.go
@@ -17,8 +17,6 @@ import (
 
 func (c Client) CreateVoice(ctx context.Context, name, description string, labels []string, files []*os.File) error {
 	url := c.endpoint + "/v1/voices/add"
-	client := &http.Client{}
-
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 	for _, r := range files {
@@ -43,7 +41,7 @@ func (c Client) CreateVoice(ctx context.Context, name, description string, label
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -69,7 +67,6 @@ func (c Client) CreateVoice(ctx context.Context, name, description string, label
 
 func (c Client) DeleteVoice(ctx context.Context, voiceID string) error {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s", voiceID)
-	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -77,7 +74,7 @@ func (c Client) DeleteVoice(ctx context.Context, voiceID string) error {
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -103,7 +100,7 @@ func (c Client) DeleteVoice(ctx context.Context, voiceID string) error {
 
 func (c Client) EditVoiceSettings(ctx context.Context, voiceID string, settings types.SynthesisOptions) error {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/settings/edit", voiceID)
-	client := &http.Client{}
+
 	b, _ := json.Marshal(settings)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
@@ -113,7 +110,7 @@ func (c Client) EditVoiceSettings(ctx context.Context, voiceID string, settings 
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -145,7 +142,6 @@ func (c Client) EditVoiceSettings(ctx context.Context, voiceID string, settings 
 
 func (c Client) EditVoice(ctx context.Context, voiceID, name, description string, labels []string, files []*os.File) error {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/edit", voiceID)
-	client := &http.Client{}
 
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
@@ -171,7 +167,7 @@ func (c Client) EditVoice(ctx context.Context, voiceID, name, description string
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -197,7 +193,7 @@ func (c Client) EditVoice(ctx context.Context, voiceID, name, description string
 
 func (c Client) GetVoiceSettings(ctx context.Context, voiceID string) (types.SynthesisOptions, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s/settings", voiceID)
-	client := &http.Client{}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return types.SynthesisOptions{}, err
@@ -205,7 +201,7 @@ func (c Client) GetVoiceSettings(ctx context.Context, voiceID string) (types.Syn
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return types.SynthesisOptions{}, err
 	}
@@ -237,7 +233,7 @@ func (c Client) GetVoiceSettings(ctx context.Context, voiceID string) (types.Syn
 
 func (c Client) GetVoice(ctx context.Context, voiceID string) (types.VoiceResponseModel, error) {
 	url := fmt.Sprintf(c.endpoint+"/v1/voices/%s", voiceID)
-	client := &http.Client{}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return types.VoiceResponseModel{}, err
@@ -245,7 +241,7 @@ func (c Client) GetVoice(ctx context.Context, voiceID string) (types.VoiceRespon
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	switch res.StatusCode {
 	case 401:
 		return types.VoiceResponseModel{}, ErrUnauthorized
@@ -279,7 +275,7 @@ func (c Client) GetVoice(ctx context.Context, voiceID string) (types.VoiceRespon
 
 func (c Client) GetVoices(ctx context.Context) ([]types.VoiceResponseModel, error) {
 	url := c.endpoint + "/v1/voices"
-	client := &http.Client{}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []types.VoiceResponseModel{}, err
@@ -287,7 +283,7 @@ func (c Client) GetVoices(ctx context.Context) ([]types.VoiceResponseModel, erro
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	req.Header.Set("accept", "application/json")
-	res, err := client.Do(req)
+	res, err := c.httpClient.Do(req)
 	switch res.StatusCode {
 	case 401:
 		return []types.VoiceResponseModel{}, ErrUnauthorized


### PR DESCRIPTION
Add an option to provide custom http.Client. The main use case is to add custom observability via custom transport.

I would have preferred to modify the New method signature to use Options instead, but I don't want to make breaking changes, so I am sticking to the existing convention.  