### PR TITLE
chore(deps): update Go to 1.26, bump purego, fix lint warning

### DIFF
--- a/client/types/types.go
+++ b/client/types/types.go
@@ -40,9 +40,8 @@ func (so *SynthesisOptions) Clamp() {
 	if so.Style > 1 || so.Style < 0 {
 		so.Style = 0.0
 	}
-	if so.UseSpeakerBoost != true && so.UseSpeakerBoost != false {
-		so.UseSpeakerBoost = true
-	}
+	// UseSpeakerBoost defaults to the zero value (false) for bool;
+	// no conditional needed as the caller sets it explicitly.
 }
 
 type SynthesisOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/taigrr/elevenlabs
 
-go 1.24.0
+go 1.26.0
 
 require github.com/gopxl/beep/v2 v2.1.1
 
 require (
 	github.com/ebitengine/oto/v3 v3.4.0 // indirect
-	github.com/ebitengine/purego v0.9.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
 github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
-github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
-github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
+github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/gopxl/beep/v2 v2.1.1 h1:6FYIYMm2qPAdWkjX+7xwKrViS1x0Po5kDMdRkq8NVbU=
 github.com/gopxl/beep/v2 v2.1.1/go.mod h1:ZAm9TGQ9lvpoiFLd4zf5B1IuyxZhgRACMId1XJbaW0E=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=


### PR DESCRIPTION
## Changes

- Updated Go version from 1.24.0 to 1.26.0
- Bumped `ebitengine/purego` v0.9.1 → v0.10.0
- Removed dead code in `SynthesisOptions.Clamp()` — the bool comparison `UseSpeakerBoost != true && UseSpeakerBoost != false` was always false (staticcheck S1002)

## Testing

- `go build ./...` passes
- `staticcheck ./...` clean
- No test files in repo