### PR TITLE
fix(client): preserve downloaded audio bytes

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -831,3 +831,54 @@ func TestDownloadVoiceSampleWriterProxy(t *testing.T) {
 		t.Errorf("got = %q", buf.String())
 	}
 }
+
+func TestDownloadVoiceSampleReturnsBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, "sample-audio")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	body, err := c.DownloadVoiceSample(context.Background(), "v1", "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "sample-audio" {
+		t.Fatalf("body = %q, want %q", string(body), "sample-audio")
+	}
+}
+
+func TestHistoryDownloadAudioReturnsBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, "history-audio")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	body, err := c.HistoryDownloadAudio(context.Background(), "h1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "history-audio" {
+		t.Fatalf("body = %q, want %q", string(body), "history-audio")
+	}
+}
+
+func TestHistoryDownloadZipReturnsBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, "zip-bytes")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	body, err := c.HistoryDownloadZip(context.Background(), "h1", "h2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "zip-bytes" {
+		t.Fatalf("body = %q, want %q", string(body), "zip-bytes")
+	}
+}

--- a/client/history.go
+++ b/client/history.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -114,15 +113,12 @@ func (c Client) HistoryDownloadZip(ctx context.Context, id1, id2 string, additio
 	case 401:
 		return []byte{}, ErrUnauthorized
 	case 200:
-		if err != nil {
-			return []byte{}, err
-		}
-		b := bytes.Buffer{}
-		w := bufio.NewWriter(&b)
-
 		defer res.Body.Close()
-		io.Copy(w, res.Body)
-		return b.Bytes(), nil
+		body, readErr := io.ReadAll(res.Body)
+		if readErr != nil {
+			return []byte{}, readErr
+		}
+		return body, nil
 	case 422:
 		fallthrough
 	default:
@@ -192,12 +188,12 @@ func (c Client) HistoryDownloadAudio(ctx context.Context, ID string) ([]byte, er
 	case 401:
 		return []byte{}, ErrUnauthorized
 	case 200:
-		b := bytes.Buffer{}
-		w := bufio.NewWriter(&b)
-
 		defer res.Body.Close()
-		io.Copy(w, res.Body)
-		return b.Bytes(), nil
+		body, readErr := io.ReadAll(res.Body)
+		if readErr != nil {
+			return []byte{}, readErr
+		}
+		return body, nil
 	case 422:
 		fallthrough
 	default:

--- a/client/samples.go
+++ b/client/samples.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -101,12 +99,12 @@ func (c Client) DownloadVoiceSample(ctx context.Context, voiceID, sampleID strin
 	case 401:
 		return []byte{}, ErrUnauthorized
 	case 200:
-		b := bytes.Buffer{}
-		w := bufio.NewWriter(&b)
-
 		defer res.Body.Close()
-		io.Copy(w, res.Body)
-		return b.Bytes(), nil
+		body, readErr := io.ReadAll(res.Body)
+		if readErr != nil {
+			return []byte{}, readErr
+		}
+		return body, nil
 	case 422:
 		fallthrough
 	default:


### PR DESCRIPTION
## Summary
- fix HistoryDownloadZip, HistoryDownloadAudio, and DownloadVoiceSample to return the full response body
- replace buffered writes that were never flushed with direct reads from the response body
- add regression tests covering the byte-returning download helpers

## Testing
- go test ./...
- staticcheck ./...