### PR TITLE
fix(client): propagate writer copy errors

### DIFF
--- a/client/samples.go
+++ b/client/samples.go
@@ -64,8 +64,8 @@ func (c Client) DownloadVoiceSampleWriter(ctx context.Context, w io.Writer, voic
 		return ErrUnauthorized
 	case 200:
 		defer res.Body.Close()
-		io.Copy(w, res.Body)
-		return nil
+		_, err = io.Copy(w, res.Body)
+		return err
 	case 422:
 		fallthrough
 	default:

--- a/client/tts.go
+++ b/client/tts.go
@@ -39,8 +39,8 @@ func (c Client) TTSWriter(ctx context.Context, w io.Writer, text, modelID, voice
 		return err
 	}
 	defer body.Close()
-	io.Copy(w, body)
-	return nil
+	_, err = io.Copy(w, body)
+	return err
 }
 
 func (c Client) TTS(ctx context.Context, text, voiceID, modelID string, options types.SynthesisOptions, optionalParams ...types.TTSParam) ([]byte, error) {
@@ -78,8 +78,8 @@ func (c Client) TTSStream(ctx context.Context, w io.Writer, text, voiceID string
 		return err
 	}
 	defer body.Close()
-	io.Copy(w, body)
-	return nil
+	_, err = io.Copy(w, body)
+	return err
 }
 
 func (c Client) requestTTS(ctx context.Context, params types.TTS, options types.SynthesisOptions) (io.ReadCloser, error) {

--- a/client/writer_error_test.go
+++ b/client/writer_error_test.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/taigrr/elevenlabs/client/types"
+)
+
+func TestTTSWriterReturnsCopyError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "audio-stream")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	err := c.TTSWriter(context.Background(), failingWriter{}, "hello", "model1", "voice1", types.SynthesisOptions{})
+	if err == nil || err.Error() != "write failed" {
+		t.Fatalf("err = %v, want write failed", err)
+	}
+}
+
+func TestTTSStreamReturnsCopyError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "audio-stream")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	err := c.TTSStream(context.Background(), failingWriter{}, "hello", "voice1", types.SynthesisOptions{})
+	if err == nil || err.Error() != "write failed" {
+		t.Fatalf("err = %v, want write failed", err)
+	}
+}
+
+func TestDownloadVoiceSampleWriterReturnsCopyError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "sample-stream")
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	err := c.DownloadVoiceSampleWriter(context.Background(), failingWriter{}, "voice1", "sample1")
+	if err == nil || err.Error() != "write failed" {
+		t.Fatalf("err = %v, want write failed", err)
+	}
+}


### PR DESCRIPTION
## Summary
- return `io.Copy` failures from the TTS writer helpers instead of reporting false success
- return `io.Copy` failures from voice sample downloads as well
- add regression coverage for all three writer helpers

## Testing
- go test -race ./...
- staticcheck ./...