### PR TITLE
test(client): cover STT file paths and voice edit multipart

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -578,6 +580,48 @@ func TestConvertSpeechToTextUnauthorized(t *testing.T) {
 	}
 }
 
+func TestConvertSpeechToTextOpensFilePath(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatal(err)
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer file.Close()
+
+		body, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Filename != "sample.wav" {
+			t.Fatalf("filename = %q, want sample.wav", header.Filename)
+		}
+		if string(body) != "fake-audio-file" {
+			t.Fatalf("body = %q, want fake-audio-file", string(body))
+		}
+
+		_ = json.NewEncoder(w).Encode(types.SpeechToTextResponse{Text: "ok"})
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	dir := t.TempDir()
+	audioFile := filepath.Join(dir, "sample.wav")
+	if err := os.WriteFile(audioFile, []byte("fake-audio-file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := c.ConvertSpeechToText(context.Background(), audioFile, types.SpeechToTextRequest{ModelID: types.SpeechToTextModelScribeV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "ok" {
+		t.Fatalf("text = %q, want ok", resp.Text)
+	}
+}
+
 // --- Types tests ---
 
 func TestSynthesisOptionsClamp(t *testing.T) {
@@ -745,6 +789,10 @@ func TestCreateVoiceFieldNames(t *testing.T) {
 		if name != "TestVoice" {
 			t.Errorf("name = %q", name)
 		}
+		description := r.FormValue("description")
+		if description != "A test voice" {
+			t.Errorf("description = %q", description)
+		}
 		labels := r.FormValue("labels")
 		if labels != "english, male" {
 			t.Errorf("labels = %q, want %q", labels, "english, male")
@@ -755,6 +803,50 @@ func TestCreateVoiceFieldNames(t *testing.T) {
 
 	c := newTestClient(ts)
 	err := c.CreateVoice(context.Background(), "TestVoice", "A test voice", []string{"english", "male"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEditVoiceFieldNamesAndFiles(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAPIKey(t, r)
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatal(err)
+		}
+		if name := r.FormValue("name"); name != "Updated Voice" {
+			t.Fatalf("name = %q, want Updated Voice", name)
+		}
+		if description := r.FormValue("description"); description != "New description" {
+			t.Fatalf("description = %q, want New description", description)
+		}
+		if labels := r.FormValue("labels"); labels != "calm, narrator" {
+			t.Fatalf("labels = %q, want calm, narrator", labels)
+		}
+		files := r.MultipartForm.File["files[]"]
+		if len(files) != 1 {
+			t.Fatalf("len(files[]) = %d, want 1", len(files))
+		}
+		if files[0].Filename != "clip.wav" {
+			t.Fatalf("filename = %q, want clip.wav", files[0].Filename)
+		}
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts)
+	dir := t.TempDir()
+	voiceFile := filepath.Join(dir, "clip.wav")
+	if err := os.WriteFile(voiceFile, []byte("voice-sample"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(voiceFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	err = c.EditVoice(context.Background(), "voice-id", "Updated Voice", "New description", []string{"calm", "narrator"}, []*os.File{f})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- add coverage for ConvertSpeechToText opening a file path and preserving the uploaded filename/body
- verify CreateVoice includes description in multipart form data
- verify EditVoice sends expected multipart fields and attached file names

## Testing
- go test -race ./...
- staticcheck ./...