### PR TITLE
fix(client): handle history zip transport errors

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1118,6 +1118,23 @@ func TestHistoryDeleteTransportError(t *testing.T) {
 	}
 }
 
+func TestHistoryDownloadZipTransportError(t *testing.T) {
+	transportErr := errors.New("transport failed")
+	c := New("test-api-key").WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, transportErr
+		}),
+	})
+
+	body, err := c.HistoryDownloadZip(context.Background(), "h1", "h2")
+	if len(body) != 0 {
+		t.Fatalf("body = %q, want empty", string(body))
+	}
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("err = %v, want %v", err, transportErr)
+	}
+}
+
 func TestHistoryDownloadAudioWriterReturnsCopyError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/client/history.go
+++ b/client/history.go
@@ -108,6 +108,9 @@ func (c Client) HistoryDownloadZip(ctx context.Context, id1, id2 string, additio
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("User-Agent", "github.com/taigrr/elevenlabs")
 	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return []byte{}, err
+	}
 
 	switch res.StatusCode {
 	case 401:


### PR DESCRIPTION
## Summary
- return transport errors from HistoryDownloadZip before reading the response status
- add a regression test for failed history zip requests

## Tests
- go generate ./...
- go test -race ./...
- staticcheck ./...