### PR TITLE
fix(client): close speech-to-text response bodies

### DIFF
--- a/client/stt.go
+++ b/client/stt.go
@@ -94,6 +94,7 @@ func (c Client) ConvertSpeechToTextFromReader(ctx context.Context, reader io.Rea
 	case 401:
 		return nil, ErrUnauthorized
 	case 200:
+		defer res.Body.Close()
 		var sttResponse types.SpeechToTextResponse
 		if err := json.NewDecoder(res.Body).Decode(&sttResponse); err != nil {
 			return nil, fmt.Errorf("failed to parse API response: %w", err)

--- a/client/stt_body_test.go
+++ b/client/stt_body_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/taigrr/elevenlabs/client/types"
+)
+
+type closeTrackingBody struct {
+	*strings.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestConvertSpeechToTextFromReaderClosesResponseBody(t *testing.T) {
+	body := &closeTrackingBody{
+		Reader: strings.NewReader(`{"language_code":"en","language_probability":0.99,"text":"hello"}`),
+	}
+
+	c := New("test-api-key").WithHTTPClient(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/v1/speech-to-text" {
+				t.Fatalf("path = %q, want /v1/speech-to-text", req.URL.Path)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       body,
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	response, err := c.ConvertSpeechToTextFromReader(
+		context.Background(),
+		strings.NewReader("audio"),
+		"sample.mp3",
+		types.SpeechToTextRequest{ModelID: types.SpeechToTextModelScribeV1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Text != "hello" {
+		t.Fatalf("text = %q, want hello", response.Text)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}


### PR DESCRIPTION
## Summary
- close successful speech-to-text response bodies after decoding
- add a regression test with a tracked response body

## Tests
- go generate ./...
- go test -race ./...
- staticcheck ./...